### PR TITLE
resources and volume mounts are not dependent on args

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -35,6 +35,7 @@ spec:
             {{- with $job.args }}
             args:
 {{ toYaml . | indent 12 }}
+              {{- end }}
             {{- with $job.resources }}
             resources:
 {{ toYaml . | indent 14 }}
@@ -43,7 +44,6 @@ spec:
             volumeMounts:
 {{ toYaml . | indent 12 }}
             {{- end }}
-              {{- end }}
           {{- with $job.nodeSelector }}
           nodeSelector:
 {{ toYaml . | indent 12 }}


### PR DESCRIPTION
At the moment it is not possible to add`volumeMounts` and `resources` to a cronjob unless `args` are defined in a job. This PR fixes that so that each of these resources can be created independently
