### PR TITLE
fix: support helm version 2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 name: helm-cronjobs
 description: A chart for cron jobs
 version: 1.0.0


### PR DESCRIPTION
Helm version 2 doesn't support the apiVersion 2, to make it work I had to change the apiVersion to 1.

I guess it will also work for helm 3