### PR TITLE
Enhancements and fixes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: helm-cronjobs
 description: A chart for cron jobs
-version: 1.0.1
+version: 2.0.0
 keywords:
   - cron
 home: "https://github.com/bambash"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ jobs:
     concurrencyPolicy: <concurrency_policy>
     restartPolicy: <restart_policy>
   ### OPTIONAL ###
+    imagePullSecrets:
+    - username: <user>
+      password: <password>
+      email: <email>
+      registry: <registry>
     env:
     - name: ENV_VAR
       value: ENV_VALUE

--- a/README.md
+++ b/README.md
@@ -25,11 +25,27 @@ You can define an array of jobs in values.yaml helm will take care of creating a
     ```
 
 ## Configuration
-template:
+
+Via `values.yaml`
+
+### Overview
+
+```yaml
+jobs:
+  jobname-1:
+    # job definition
+  jobname-2:
+    # job definition
+  jobname-n:
+    # job definition
+```
+
+### Details
+
 ```yaml
 jobs:
   ### REQUIRED ###
-  - name: <job_name>
+  <job_name>:
     image:
       repository: <image_repo>
       tag: <image_tag>

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -25,3 +25,27 @@ Expand the release name of the chart.
 {{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
+{{/*
+Create payload for any image pull secret.
+One kube secret will be created containing all the auths
+and will be shared by all the job pods requiring it.
+*/}}
+{{- define "cronjobs.imageSecrets" -}}
+    {{- $secrets := dict -}}
+    {{- range $jobname, $job := .Values.jobs -}}
+        {{- if hasKey $job "imagePullSecrets" -}}
+            {{- range $ips := $job.imagePullSecrets -}}
+                {{- $_ := set $secrets $ips.registry (dict "username" $ips.username "password" $ips.password "email" $ips.email "auth" (printf "%s:%s" $ips.username $ips.password | b64enc)) -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if gt (len $secrets) 0 -}}
+        {{- $auth := dict "auths" $secrets -}}
+        {{/* Emit secret content as base64 */}}
+        {{- print ($auth | toJson | b64enc) -}}
+    {{- else -}}
+        {{/* There are no secrets*/}}
+        {{- print "" -}}
+    {{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -36,7 +36,11 @@ and will be shared by all the job pods requiring it.
     {{- range $jobname, $job := .Values.jobs -}}
         {{- if hasKey $job "imagePullSecrets" -}}
             {{- range $ips := $job.imagePullSecrets -}}
-                {{- $_ := set $secrets $ips.registry (dict "username" $ips.username "password" $ips.password "email" $ips.email "auth" (printf "%s:%s" $ips.username $ips.password | b64enc)) -}}
+                {{- $userInfo := dict "username" $ips.username "password" $ips.password "auth" (printf "%s:%s" $ips.username $ips.password | b64enc) -}}
+                {{- if hasKey $ips "email" -}}
+                    {{ $_ := set $userInfo  "email" $ips.email -}}
+                {{- end -}}
+                {{- $_ := set $secrets $ips.registry $userInfo -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ include "cronjobs.releaseName" $ }}-{{ $jobname }}"
+  name: {{ include "cronjobs.releaseName" $ }}-{{ $jobname }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
 spec:
@@ -17,12 +17,14 @@ spec:
             app: {{ include "cronjobs.releaseName" $ }}
             cron: {{ $jobname }}
         spec:
-        {{- if hasKey $job "serviceAccount" }}
-        {{- if hasKey $job.serviceAccount "name" }}
+        {{- if hasKey $job "imagePullSecrets" }}
+          imagePullSecrets:
+          - name: {{ $.Release.Name }}-docker
+        {{- end }}
+        {{- if and (hasKey $job "serviceAccount") (hasKey $job.serviceAccount "name") }}
           serviceAccountName: {{ $job.serviceAccount.name }}
         {{- else }}
-          serviceAccountName: {{ $jobname }}
-        {{- end }}
+          serviceAccountName: {{ $.Release.Name}}-{{ $jobname }}
         {{- end }}
         {{- if hasKey $job "securityContext" }}
           {{- if $job.securityContext.runAsUser }}
@@ -37,7 +39,7 @@ spec:
           {{- end }}
         {{- end }}
           containers:
-          - image: "{{ $job.image.repository }}:{{ $job.image.tag }}"
+          - image: {{ $job.image.repository }}:{{ $job.image.tag }}
             imagePullPolicy: {{ $job.image.imagePullPolicy }}
             name: {{ $jobname }}
             {{- with $job.env }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -1,9 +1,9 @@
-{{- range $job := .Values.jobs }}
+{{- range $jobname, $job := .Values.jobs }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ include "cronjobs.releaseName" $ }}-{{ $job.name }}"
+  name: "{{ include "cronjobs.releaseName" $ }}-{{ $jobname }}"
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
 spec:
@@ -15,13 +15,13 @@ spec:
         metadata:
           labels:
             app: {{ include "cronjobs.releaseName" $ }}
-            cron: {{ $job.name }}
+            cron: {{ $jobname }}
         spec:
         {{- if hasKey $job "serviceAccount" }}
         {{- if hasKey $job.serviceAccount "name" }}
           serviceAccountName: {{ $job.serviceAccount.name }}
         {{- else }}
-          serviceAccountName: {{ $job.name }}
+          serviceAccountName: {{ $jobname }}
         {{- end }}
         {{- end }}
         {{- if hasKey $job "securityContext" }}
@@ -39,7 +39,7 @@ spec:
           containers:
           - image: "{{ $job.image.repository }}:{{ $job.image.tag }}"
             imagePullPolicy: {{ $job.image.imagePullPolicy }}
-            name: {{ $job.name }}
+            name: {{ $jobname }}
             {{- with $job.env }}
             env:
 {{ toYaml . | indent 12 }}

--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -50,8 +50,9 @@ spec:
             envFrom:
 {{ toYaml . | indent 12 }}
             {{- end }}
-            {{- if $job.command }}
-            command: {{ $job.command }}
+            {{- with $job.command }}
+            command:
+{{ toYaml . | indent 12 }}
             {{- end }}
             {{- with $job.args }}
             args:

--- a/templates/image-pull-secret.yaml
+++ b/templates/image-pull-secret.yaml
@@ -1,0 +1,12 @@
+{{- $secret := (include "cronjobs.imageSecrets" .) -}}
+{{- if gt (len $secret) 0 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-docker
+  labels:
+    {{- include "cronjobs.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $secret }}
+{{- end -}}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- range $job := .Values.jobs }}
+{{- range $jobname, $job := .Values.jobs }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -6,11 +6,11 @@ metadata:
   {{- if and (hasKey $job "serviceAccount") (hasKey $job "serviceAccount.name") }}
   name: {{ $job.serviceAccount.name }}
   {{- else }}
-  name: {{ $job.name }}
+  name: {{ $jobname }}
   {{- end }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
-    cron: {{ $job.name }}
+    cron: {{ $jobname }}
   {{- if and (hasKey $job "serviceAccount") (hasKey $job "serviceAccount.annotations") }}
   {{- with $job.serviceAccount.annotations }}
   annotations:

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if and (hasKey $job "serviceAccount") (hasKey $job "serviceAccount.name") }}
   name: {{ $job.serviceAccount.name }}
   {{- else }}
-  name: {{ $jobname }}
+  name: {{ $.Release.Name}}-{{ $jobname }}
   {{- end }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 # Declare variables to be passed into your templates.
 jobs:
   # first cron
-  - name: hello-world
+  hello-world:
     image:
       repository: hello-world
       tag: latest
@@ -13,7 +13,7 @@ jobs:
     concurrencyPolicy: Allow
     restartPolicy: OnFailure
   # second cron
-  - name: hello-ubuntu
+  hello-ubuntu:
     image:
       repository: ubuntu
       tag: latest
@@ -35,7 +35,7 @@ jobs:
     concurrencyPolicy: Forbid
     restartPolicy: OnFailure
   # third cron
-  - name: hello-env-var
+  hello-env-var:
     securityContext:
       runAsUser: 1000
       runAsGroup: 1000

--- a/values.yaml
+++ b/values.yaml
@@ -15,7 +15,6 @@ jobs:
     imagePullSecrets:
     - username: fred
       password: password
-      email: fred@example.com
       registry: docker.io
   # second cron
   hello-ubuntu:

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,11 @@ jobs:
     successfulJobsHistoryLimit: 3
     concurrencyPolicy: Allow
     restartPolicy: OnFailure
+    imagePullSecrets:
+    - username: fred
+      password: password
+      email: fred@example.com
+      registry: docker.io
   # second cron
   hello-ubuntu:
     image:
@@ -34,6 +39,11 @@ jobs:
     successfulJobsHistoryLimit: 3
     concurrencyPolicy: Forbid
     restartPolicy: OnFailure
+    imagePullSecrets:
+    - username: joe
+      password: password2
+      email: joe@example.com
+      registry: quay.io
   # third cron
   hello-env-var:
     securityContext:


### PR DESCRIPTION
* Change `jobs` in values.yaml from list to map of maps where `jobname` is the key. Easier to `--set` values for individual jobs
* Add support for `imagePullSecrets`. If any jobs define this, 
    * One kube secret is created containing all auths
    * Jobs that declare `imagePullSecrets` are associated with this kube secret
* Fix `command` rendering. Needs to be handled the same way as `args`